### PR TITLE
Bugfix & delete clusterIPs field as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ By default this fields are being removed:
     "managedFields": " "
 },
 "spec": {
-    "clusterIP:": " ",
+    "clusterIP": " ",
+    "clusterIPs": " ",
     "finalizers": " "
 },
 "status": " "

--- a/clean.py
+++ b/clean.py
@@ -28,7 +28,7 @@ FIELDS_TO_RM = {
         "managedFields": " "
     },
     "spec": {
-        "clusterIP:": " ",
+        "clusterIP": " ",
         "finalizers": " "
     },
     "status": " "

--- a/clean.py
+++ b/clean.py
@@ -29,6 +29,7 @@ FIELDS_TO_RM = {
     },
     "spec": {
         "clusterIP": " ",
+        "clusterIPs": " ",
         "finalizers": " "
     },
     "status": " "


### PR DESCRIPTION
Hey,
Thanks for your helpful script.
I found a typo that I corrected, namely the superfluous colon in the `"clusterIP:": "  "` field that I removed.
Additionally I added the field `clusterIPs` to be removed additionally to `clusterIP`.

Best Regards!